### PR TITLE
Feature/Use Immutable image tag for lambda container

### DIFF
--- a/app/functions/version/main.go
+++ b/app/functions/version/main.go
@@ -31,7 +31,7 @@ func main() {
 
 func Handler(ctx context.Context, req Request) (Response, error) {
 	fmt.Println("start version function")
-	fmt.Println("this is v2")
+	fmt.Println("this is v3")
 	fmt.Println(req)
 	ssmValue, err := getParameter(ctx)
 	if err != nil {

--- a/app/functions/version/main.go
+++ b/app/functions/version/main.go
@@ -31,6 +31,7 @@ func main() {
 
 func Handler(ctx context.Context, req Request) (Response, error) {
 	fmt.Println("start version function")
+	fmt.Println("this is v2")
 	fmt.Println(req)
 	ssmValue, err := getParameter(ctx)
 	if err != nil {

--- a/infra/aws/ecr.tf
+++ b/infra/aws/ecr.tf
@@ -1,3 +1,4 @@
 resource "aws_ecr_repository" "go_lambda" {
-  name = "takekou-go-lambda"
+  name                 = "takekou-go-lambda"
+  image_tag_mutability = "IMMUTABLE"
 }

--- a/infra/aws/lambda.tf
+++ b/infra/aws/lambda.tf
@@ -1,7 +1,7 @@
 resource "aws_lambda_function" "go_lambda" {
   function_name = "takekou-go-lambda"
   package_type  = "Image"
-  image_uri     = "${aws_ecr_repository.go_lambda.repository_url}:latest"
+  image_uri     = "${aws_ecr_repository.go_lambda.repository_url}:${var.image_tag}"
   role          = aws_iam_role.lambda.arn
   publish       = true
   architectures = ["arm64"]
@@ -17,10 +17,6 @@ resource "aws_lambda_function" "go_lambda" {
 
   image_config {
     entry_point = ["/functions/version"]
-  }
-
-  lifecycle {
-    ignore_changes = [image_uri]
   }
 }
 

--- a/infra/aws/variables.tf
+++ b/infra/aws/variables.tf
@@ -1,0 +1,3 @@
+variable "image_tag" {
+  type = string
+}


### PR DESCRIPTION
Mutable latest tag is dangerous.
So Immutable image tag (ex. commit hash from `git rev-parse HEAD`) should be used.

- set ECR Immutable flag
- add variable image_tag to terraform
- specify image_tag in lambda image_url

You can deploy lambda function in the following steps. 
- build docker image
- push docker image with tag (ex. commit hash)
- terraform apply with image_tag variable